### PR TITLE
Fixed some errors with const and PROGMEM

### DIFF
--- a/demo/main.c
+++ b/demo/main.c
@@ -57,7 +57,7 @@
  * If you want to receive both 11 and 29 bit identifiers, set your filters
  * and masks as follows:
  */
-prog_uint8_t can_filter[] = 
+const prog_uint8_t can_filter[] = 
 {
 	// Group 0
 	MCP2515_FILTER(0),				// Filter 0

--- a/src/mcp2515.c
+++ b/src/mcp2515.c
@@ -125,7 +125,7 @@ uint8_t mcp2515_read_status(uint8_t type)
 
 // -------------------------------------------------------------------------
 
-prog_uint8_t _mcp2515_cnf[8][3] = {
+const prog_uint8_t _mcp2515_cnf[8][3] = {
 	// 10 kbps
 	{	0x04,
 		0xb6,


### PR DESCRIPTION
Hallo,

some variables "must be const in order to be put into read-only section by means of '**attribute**((progmem))'."

I fixed this at least for the default configuration. 

Please pull the changes into your code.

Thanks

Kind regards

Mebus
