### PR TITLE
added a warning in bundled config.h / support for can_config.h

### DIFF
--- a/can.h
+++ b/can.h
@@ -58,7 +58,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifndef CAN_CONFIG_LOADED
+#ifdef HAS_CAN_CONFIG_H
+/* try to load can_config.h */
+#include "can_config.h"
+#else
+/* try to load config.h - compatibility */
 #include "config.h"
+#endif
+#endif
 
 // ----------------------------------------------------------------------------
 /** \ingroup	can_interface

--- a/src/config.h
+++ b/src/config.h
@@ -1,6 +1,8 @@
 #ifndef	CONFIG_H
 #define	CONFIG_H
 
+#warning Default config.h used!
+#define CAN_CONFIG_LOADED
 // -----------------------------------------------------------------------------
 /* Global settings for building the can-lib and application program.
  *


### PR DESCRIPTION
The warning should be usefull because in my opinion the user should
create it's own config.h before compiling.

Whenever he forgets to add the correct include path the compiler may
still use the bundled default config.h - so a warning would be
usefull.

Another point is, that I'm not compiling any kind of library. I'm
directly including the files. I've already other modules with their
own config like modbus_config.h and so on. Thus it'd make sense to
change the config filename of avr-can-lib to something like
can_config.h .

If the makro HAS_CAN_CONFIG_H is defined, the compiler will use the
file can_config.h instead of config.h .
