### PR TITLE
fix error with config switch

### DIFF
--- a/src/can_private.h
+++ b/src/can_private.h
@@ -31,7 +31,7 @@
 #ifndef	CAN_PRIVATE_H
 #define	CAN_PRIVATE_H
 
-#include "config.h"
+#include "can.h"
 
 #ifndef	CAN_FORCE_TX_ORDER
 	#define	CAN_FORCE_TX_ORDER		0


### PR DESCRIPTION
With this change, it is possible to run cmake/make outside the library folder with own can_config.h and `HAS_CAN_CONFIG_H` define

see: https://github.com/rennerm/libcanard/tree/feature/at90can128/drivers/AVR