### PR TITLE
Support for ATmega16/32/64m1/c1

### DIFF
--- a/src/at90can_private.h
+++ b/src/at90can_private.h
@@ -47,11 +47,29 @@
 
 #if (defined (__AVR_AT90CAN32__) || \
 	 defined (__AVR_AT90CAN64__) || \
-	 defined (__AVR_AT90CAN128__)) && \
+	 defined (__AVR_AT90CAN128__) || \
+	 defined (__AVR_ATmega16M1__) || \
+	 defined (__AVR_ATmega32M1__) || \
+	 defined (__AVR_ATmega64M1__) || \
+	 defined (__AVR_ATmega32C1__) || \
+	 defined (__AVR_ATmega64C1__)) && \
 	 BUILD_FOR_AT90CAN == 1
 
 #if F_CPU != 16000000UL
 	#error	only 16 MHz for F_CPU supported!
+#endif
+
+#if (defined (__AVR_ATmega16M1__) || \
+	 defined (__AVR_ATmega32M1__) || \
+	 defined (__AVR_ATmega64M1__) || \
+	 defined (__AVR_ATmega32C1__) || \
+	 defined (__AVR_ATmega64C1__))
+// The interrupt vectors are named diffently in the standard lib, but they
+// are exactly the same.
+#define CANIT_vect CAN_INT_vect
+#define CANIT_vect_num CAN_INT_vect_num
+#define OVRIT_vect CAN_TOVF_vect
+#define OVRIT_vect_num CAN_TOVF_vect_num
 #endif
 
 #define	SUPPORT_FOR_AT90CAN__		1


### PR DESCRIPTION
The [ATmega16M1/ATmega32M1/ATmega64M1/ATmega32C1/ATmega64C1](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7647-Automotive-Microcontrollers-ATmega16M1-32M1-64M1-32C1-64C1_datasheet.pdf) microcontrollers have the same CAN controller built in as AT90CAN*. There are some minor differences in the standard AVR headers, such as differently named interrupt vectors. But the registers and programming interface are the same.

Here is a simple patch to add support for these MCUs.