### PR TITLE
Support for ATmega16M1, ATmega32M1, ATmega64M1, ATmega32C1, ATmega64C1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+add_library(can
+    src/at90can.c
+    src/at90can_buffer.c
+    src/at90can_disable_dyn_filter.c
+    src/at90can_error_register.c
+    src/at90can_get_buf_message.c
+    src/at90can_get_dyn_filter.c
+    src/at90can_get_message.c
+    src/at90can_private.h
+    src/at90can_send_buf_message.c
+    src/at90can_send_message.c
+    src/at90can_set_dyn_filter.c
+    src/at90can_set_mode.c
+    src/can_buffer.c
+    src/mcp2515.c
+    src/mcp2515_buffer.c
+    src/mcp2515_defs.h
+    src/mcp2515_error_register.c
+    src/mcp2515_get_dyn_filter.c
+    src/mcp2515_get_message.c
+    src/mcp2515_private.h
+    src/mcp2515_read_id.c
+    src/mcp2515_regdump.c
+    src/mcp2515_send_message.c
+    src/mcp2515_set_dyn_filter.c
+    src/mcp2515_set_mode.c
+    src/mcp2515_sleep.c
+    src/mcp2515_static_filter.c
+    src/mcp2515_write_id.c
+    src/sja1000.c
+    src/sja1000_buffer.c
+    src/sja1000_error_register.c
+    src/sja1000_get_message.c
+    src/sja1000_send_message.c
+    src/sja1000_set_mode.c
+    src/spi.c
+)
+
+target_include_directories(can
+    PUBLIC
+    ./
+)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Features
 * Unterstützung des MCP2515
 * Unterstützung des SJA1000 (für AVRs mit oder ohne externem Bus-Interface!)
 * Unterstützung der AT90CAN-Reihe
+* Unterstützung der ATmegaxxM1/C1-Reihe (ATmega16M1/ATmega32M1/ATmega64M1/ATmega32C1/ATmega64C1)
 * Aufbau als Library, damit werden nur die benötigen Funktionen verwendet
 * geringer Resourcen-Verbrauch
 

--- a/src/at90can.c
+++ b/src/at90can.c
@@ -111,7 +111,7 @@ uint8_t _find_free_mob(void)
 	#endif
 	
 	uint8_t i;
-	for (i = 0;i < 15;i++)
+	for (i = 0;i < CAN_MOB_COUNT;i++)
 	{
 		// load MOb page
 		CANPAGE = i << 4;
@@ -148,7 +148,7 @@ void _enable_mob_interrupt(uint8_t mob)
 
 // ----------------------------------------------------------------------------
 
-bool at90can_init(uint8_t bitrate)
+bool at90can_init(can_bitrate_t bitrate)
 {
 	if (bitrate >= 8)
 		return false;
@@ -163,7 +163,7 @@ bool at90can_init(uint8_t bitrate)
 	CANBT3 = pgm_read_byte(&_at90can_cnf[bitrate][2]);
 	
 	// activate CAN transmit- and receive-interrupt
-	CANGIT = 0;
+	// CANGIT = 0; // initial value is 0 and you can't reset by writing 0
 	CANGIE = (1 << ENIT) | (1 << ENRX) | (1 << ENTX);
 	
 	// set timer prescaler to 199 which results in a timer
@@ -171,7 +171,7 @@ bool at90can_init(uint8_t bitrate)
 	CANTCON = 199;
 	
 	// disable all filters
-	at90can_disable_filter( 0xff );
+	at90can_disable_filter(CAN_ALL_FILTER);
 	
 	#if CAN_RX_BUFFER_SIZE > 0
 	can_buffer_init( &can_rx_buffer, CAN_RX_BUFFER_SIZE, can_rx_list );
@@ -191,11 +191,19 @@ bool at90can_init(uint8_t bitrate)
 // The CANPAGE register have to be restored after usage, otherwise it
 // could cause trouble in the application programm.
 
+#if defined(__AVR_ATmega16M1__) || \
+    defined(__AVR_ATmega32M1__) || \
+    defined(__AVR_ATmega64M1__) || \
+    defined(__AVR_ATmega32C1__) || \
+    defined(__AVR_ATmega64C1__)
+ISR(CAN_INT_vect)
+#else // AT90CAN
 ISR(CANIT_vect)
+#endif
 {
 	uint8_t canpage;
 	uint8_t mob;
-	
+
 	if ((CANHPMOB & 0xF0) != 0xF0)
 	{
 		// save MOb page register
@@ -287,6 +295,14 @@ ISR(CANIT_vect)
 
 // ----------------------------------------------------------------------------
 // Overflow of CAN timer
+#if defined(__AVR_ATmega16M1__) || \
+    defined(__AVR_ATmega32M1__) || \
+    defined(__AVR_ATmega64M1__) || \
+    defined(__AVR_ATmega32C1__) || \
+    defined(__AVR_ATmega64C1__)
+ISR(CAN_TOVF_vect) {}
+#else // AT90CAN
 ISR(OVRIT_vect) {}
+#endif
 
 #endif	// SUPPORT_FOR_AT90CAN__

--- a/src/at90can_disable_dyn_filter.c
+++ b/src/at90can_disable_dyn_filter.c
@@ -36,7 +36,7 @@
 
 bool at90can_disable_filter(uint8_t number)
 {
-	if (number > 14)
+	if (number >= CAN_MOB_COUNT)
 	{
 		if (number == CAN_ALL_FILTER)
 		{
@@ -45,7 +45,7 @@ bool at90can_disable_filter(uint8_t number)
 			CANIE2 = 0;
 			
 			// disable all MObs
-			for (uint8_t i = 0;i < 15;i++) {
+			for (uint8_t i = 0;i < CAN_MOB_COUNT;i++) {
 				CANPAGE = (i << 4);
 				
 				// disable MOb (read-write required)
@@ -59,13 +59,13 @@ bool at90can_disable_filter(uint8_t number)
 			#endif
 			
 			#if CAN_TX_BUFFER_SIZE == 0
-			_free_buffer = 15;
+			_free_buffer = CAN_MOB_COUNT;
 			#endif
 			
 			return true;
 		}
 		
-		// it is only possible to serve a maximum of 15 filters
+		// it is only possible to serve a maximum of CAN_MOB_COUNT filters
 		return false;
 	}
 	

--- a/src/at90can_get_dyn_filter.c
+++ b/src/at90can_get_dyn_filter.c
@@ -35,8 +35,8 @@
 
 uint8_t at90can_get_filter(uint8_t number, can_filter_t *filter)
 {
-	if (number > 14) {
-		// it is only possible to serve a maximum of 15 filters
+	if (number >= CAN_MOB_COUNT) {
+		// it is only possible to serve a maximum of CAN_MOB_COUNT filters
 		return 0;
 	}
 	

--- a/src/at90can_get_message.c
+++ b/src/at90can_get_message.c
@@ -122,7 +122,7 @@ uint8_t at90can_get_message(can_t *msg)
 		return 0;
 	
 	// find the MOb with the received message
-	for (mob = 0; mob < 15; mob++)
+	for (mob = 0; mob < CAN_MOB_COUNT; mob++)
 	{
 		CANPAGE = mob << 4;
 		

--- a/src/at90can_private.h
+++ b/src/at90can_private.h
@@ -45,10 +45,17 @@
 
 // ----------------------------------------------------------------------------
 
-#if (defined (__AVR_AT90CAN32__) || \
-	 defined (__AVR_AT90CAN64__) || \
-	 defined (__AVR_AT90CAN128__)) && \
-	 BUILD_FOR_AT90CAN == 1
+#if BUILD_FOR_AT90CAN == 1
+
+#if defined(__AVR_ATmega16M1__) || \
+    defined(__AVR_ATmega32M1__) || \
+    defined(__AVR_ATmega64M1__) || \
+    defined(__AVR_ATmega32C1__) || \
+    defined(__AVR_ATmega64C1__)
+#define CAN_MOB_COUNT 6
+#else // AT90CAN
+#define CAN_MOB_COUNT 15
+#endif
 
 #if F_CPU != 16000000UL
 	#error	only 16 MHz for F_CPU supported!

--- a/src/at90can_send_message.c
+++ b/src/at90can_send_message.c
@@ -92,7 +92,7 @@ uint8_t at90can_send_message(const can_t *msg)
 {
 	// check if there is any free MOb
 	uint8_t mob = _find_free_mob();
-	if (mob >= 15)
+	if (mob >= CAN_MOB_COUNT)
 		return 0;
 	
 	// load corresponding MOb page ...

--- a/src/at90can_send_message.c
+++ b/src/at90can_send_message.c
@@ -50,14 +50,10 @@ void at90can_copy_message_to_mob(const can_t *msg)
 		// extended CAN ID
 		CANCDMOB |= (1 << IDE);
 		
-		CANIDT4 = (uint8_t)  msg->id << 3;
-		
-		uint32_t temp = msg->id << 3;
-		uint8_t *ptr = (uint8_t *) &temp;
-		
-		CANIDT3 = *(ptr + 1);
-		CANIDT2 = *(ptr + 2);
-		CANIDT1 = *(ptr + 3);
+		CANIDT4 = (uint8_t) (msg->id << 3);
+		CANIDT3 = (uint8_t) (msg->id >> 5);
+		CANIDT2 = (uint8_t) (msg->id >> (5 + 8));
+		CANIDT1 = (uint8_t) (msg->id >> (5 + 8 + 8));
 	}
 	else {
 		// standard CAN ID

--- a/src/at90can_set_dyn_filter.c
+++ b/src/at90can_set_dyn_filter.c
@@ -34,8 +34,8 @@
 // ----------------------------------------------------------------------------
 bool at90can_set_filter(uint8_t number, const can_filter_t *filter)
 {
-	if (number > 14) {
-		// it is only possible to serve a maximum of 15 filters
+	if (number >= CAN_MOB_COUNT) {
+		// it is only possible to serve a maximum of CAN_MOB_COUNT filters
 		return false;
 	}
 	

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,7 @@
 /* Global settings for building the can-lib.
  *
  * Select ONE CAN controller for which you are building the can-lib. 
+ * Set SUPPORT_AT90CAN to 1 to enable ATmega M1 and C1 support
  */
 #define	SUPPORT_MCP2515			1
 #define	SUPPORT_AT90CAN			0


### PR DESCRIPTION
There is already a Pull Request #22 opened by @onitake to add support for the M1 and C1 series, but it lacks the different MOb count compared to the AT90CAN.

|               | message objects |
|---------------|-----------------|
| AT90CAN       | 15              |
| ATmegaxxM1/C1 | 6               |

[Datasheet for ATmega16M1/ATmega32M1/ATmega64M1/ATmega32C1/ATmega64C1](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7647-Automotive-Microcontrollers-ATmega16M1-32M1-64M1-32C1-64C1_datasheet.pdf)

The main difference between the M1/C1 and the AT90CAN is the interrupt vector name in the header. The first commit addresses this issue.

The PR also contains one small improvement to memory usage and cmake support. These later commits are not strictly necessary for the MCU support.